### PR TITLE
Jadnast patch 1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,4 +42,4 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} 
         run: |
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
-          npm publish --access public
+          npm publish

--- a/package.json
+++ b/package.json
@@ -1,15 +1,12 @@
 {
-  "name": "@hikasami/eslint-config-react",
-  "version": "1.0.1",
+  "name": "@hksm/eslint-config-react",
+  "version": "1.0.0",
   "files": [
     "index.js",
     "prettier.config.js"
   ],
   "author": "Hikasami",
   "license": "Apache-2.0",
-  "publishConfig": {
-    "access": "public"
-  },
   "lint-staged": {
     "*.@(js|jsx)": "prettier --write"
   },


### PR DESCRIPTION
## Саммари от Sourcery

Переименование пакета и удаление поля `access` из `publishConfig`.

Технические задачи:
- Обновление имени пакета с `@hikasami/eslint-config-react` на `@hksm/eslint-config-react`.
- Удаление поля `publishConfig` и обновление команды публикации, чтобы больше не указывать публичный доступ.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename the package and remove the `access` field from `publishConfig`.

Chores:
- Update the package name from `@hikasami/eslint-config-react` to `@hksm/eslint-config-react`.
- Remove the `publishConfig` field, and update the publish command to no longer specify public access.

</details>